### PR TITLE
Fixed fetch issue

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    async rewrites() {
+        return [
+            {
+                source: '/api/:path*',
+                destination: 'http://localhost:5000/api/:path*', // Proxy to Backend
+            },
+        ];
+    },
+};
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "next": "14.2.5",
+        "next": "^14.2.5",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -3109,6 +3109,7 @@
       "version": "14.2.5",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
       "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
+      "license": "MIT",
       "dependencies": {
         "@next/env": "14.2.5",
         "@swc/helpers": "0.5.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,14 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "^14.2.5",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.2.5"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "postcss": "^8",
-    "tailwindcss": "^3.4.1",
     "eslint": "^8",
-    "eslint-config-next": "14.2.5"
+    "eslint-config-next": "14.2.5",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1"
   }
 }


### PR DESCRIPTION
Addressed issue #28 

Front end was fetching from 3000/api instead of 5000/api

Issue was that next doesnt support the use of a proxy in the package.json file. To work around this, I edited the next.config.mjs to reroute the requests to localhost:5000 effectively making a proxy. 

The package.json file says it has been changed but all the contents are still the same if you look at it