### PR TITLE
Adding Gemini API functionality to server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,19 @@
   "packages": {
     "": {
       "dependencies": {
+        "@google/generative-ai": "^0.17.0",
         "body-parser": "^1.20.2",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "mongoose": "^8.5.2"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.17.0.tgz",
+      "integrity": "sha512-HNIrX4x6EY5UPOTTDC5DepBFVluognTXR0MTWLiSVsJmzqdEYxGtz/9NWIknUbPNnPZOu7N1BoA/Ho24aPUh3g==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@google/generative-ai": "^0.17.0",
     "body-parser": "^1.20.2",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/routes/recipes.js
+++ b/routes/recipes.js
@@ -44,12 +44,11 @@ router.post('/generate', async (req, res) => {
     
     try {
         const recipeData = await generateRecipe(params);
-        console.log('Recipe Data:', recipeData);
         // remove the ```json``` and newline characters from the response
         const cleanedData = recipeData.replace(/```json|```|\n/g, '');
         let parsedData = JSON.parse(cleanedData);
 
-
+        console.log('Parsed Data:', parsedData);
         res.json(parsedData);
 
 

--- a/routes/recipes.js
+++ b/routes/recipes.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const Recipe = require('../models/recipeModel')
+const { generateRecipe } = require('../server/api/gemini/client');
 
 const router = express.Router()
 
@@ -27,5 +28,35 @@ router.delete('/:id', (req, res) => {
 router.patch('/:id', (req, res) => {
     res.json({ message: 'Update a recipe'})
 })
+
+// generating recipe using Gemini API
+router.post('/generate', async (req, res) => {
+    const { ingredients, cuisine, dietaryPreferences, mealType, servings } = req.body;
+
+    const params = {
+        ingredients: ingredients,
+        cuisine: cuisine,
+        dietaryPreferences: dietaryPreferences,
+        mealType: mealType,
+        servings: servings
+    };
+    console.log('Params:', params);
+    
+    try {
+        const recipeData = await generateRecipe(params);
+        console.log('Recipe Data:', recipeData);
+        // remove the ```json``` and newline characters from the response
+        const cleanedData = recipeData.replace(/```json|```|\n/g, '');
+        let parsedData = JSON.parse(cleanedData);
+
+
+        res.json(parsedData);
+
+
+        
+    } catch (error) {
+        res.status(500).json({ error: 'Failed to generate recipe' });
+    }
+});
 
 module.exports = router

--- a/server/api/gemini/client.js
+++ b/server/api/gemini/client.js
@@ -11,7 +11,7 @@ const generateRecipe = async (params) => {
     try {
         const prompt = "You are a recipe generator. Generate a recipe with the following details:\n1. Recipe Name\n2. List of Ingredients\n3. Step-by-Step Cooking Instructions\n4. Cooking Time\n5. Number of Servings\n from the following prompts:"
         + JSON.stringify(params)
-        +"\nFormat the response as a JSON object with fields `recipeName`, `ingredients`, `steps`, `cookingTime`, and `servings`. Your response must only be in these json fields with no other information";
+        +"\nFormat the response as a JSON object with fields `title`, `ingredients`, `cookingTime`, `instructions`. Your response must only be in these json fields with no other information";
         const result = await model.generateContent(prompt);
         const response = await result.response;
         console.log('Response:', response.text());

--- a/server/api/gemini/client.js
+++ b/server/api/gemini/client.js
@@ -1,0 +1,25 @@
+const { GoogleGenerativeAI } = require('@google/generative-ai');
+const dotenv = require('dotenv');
+dotenv.config({ path: './config.env' });
+
+const apiKey = process.env.GEMINI_API_KEY;
+const genAI = new GoogleGenerativeAI(apiKey);
+const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
+
+// Function to generate content
+const generateRecipe = async (params) => {
+    try {
+        const prompt = "You are a recipe generator. Generate a recipe with the following details:\n1. Recipe Name\n2. List of Ingredients\n3. Step-by-Step Cooking Instructions\n4. Cooking Time\n5. Number of Servings\n from the following prompts:"
+        + JSON.stringify(params)
+        +"\nFormat the response as a JSON object with fields `recipeName`, `ingredients`, `steps`, `cookingTime`, and `servings`. Your response must only be in these json fields with no other information";
+        const result = await model.generateContent(prompt);
+        const response = await result.response;
+        console.log('Response:', response.text());
+        return response.text();
+    } catch (error) {
+        console.error('Error communicating with Gemini API:', error);
+        throw error;
+    }
+};
+
+module.exports = { generateRecipe };

--- a/server/config.env
+++ b/server/config.env
@@ -1,2 +1,2 @@
 MONGO_URI=mongodb+srv://Team_7_DB_Admin:codeWarriors@recipeappcluster.ijsn4.mongodb.net/?retryWrites=true&w=majority&appName=RecipeAppCluster
-
+GEMINI_API_KEY=<your-api-key>

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.7.4",
         "body-parser": "^1.20.2",
+        "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "mongoose": "^8.5.2"
       },
@@ -73,6 +75,21 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -204,6 +221,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -273,6 +301,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -290,6 +326,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {
@@ -414,6 +461,38 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1012,6 +1091,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,9 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "axios": "^1.7.4",
     "body-parser": "^1.20.2",
+    "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "mongoose": "^8.5.2"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+const recipeRoutes = require('../routes/recipes');
 
 const app = express();
-const recipeRoutes = require('../routes/recipes');
+dotenv.config({ path: './config.env' });
 
 app.use(bodyParser.json());
 
@@ -12,10 +14,12 @@ app.use('/api/recipes', recipeRoutes);
 
 let ingredients = [];
 
+// Endpoint to retrieve ingredients
 app.get("/api", (req, res) => {
     res.json({ ing: ingredients });
 });
 
+// Endpoint to add an ingredient
 app.post("/api/add", (req, res) => {
     const { ingredient } = req.body;
     if (ingredient) {
@@ -24,16 +28,17 @@ app.post("/api/add", (req, res) => {
     res.json({ ing: ingredients });
 });
 
+// Endpoint to reset ingredients
 app.post("/api/reset", (req, res) => {
     ingredients = [];
     res.json({ ing: ingredients });
 });
 
-// Connecting to the database
-require("dotenv").config({path: "./config.env"});
-mongoose.connect(process.env.MONGO_URI)
+// Connect to MongoDB and start the server
+mongoose.connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
     .then(() => {
         app.listen(5000, () => console.log('Connected to db and server is running on port 5000.'));
     })
-    .catch((error) => console.error('Could not connect to MongoDB...'));
+    .catch((error) => console.error('Could not connect to MongoDB...', error));
 
+module.exports = app;


### PR DESCRIPTION
## Description
This adds route to call gemini api given input. Currently the input is as follows, but these can easily be changed depending on what we want:
```
{
   "ingredients": "tomato, cheese, beans",
  "cuisine": "Mexican",
  "dietaryPreferences": "None",
  "mealType": "Dinner",
  "servings": 4
}
```

Returns json with fields as follows:
```
{
    "title": "",
    "ingredients": [""],
    "cookingTime": "",
    "instructions": [""]
}
```
This hopefully follows the model schema in the models folder - will add on the image field when implementing the pexels stuff.

## Notes
This only works on the server-side, I didn't add any frontend functionality. To test this i just used postman and made post requests to `http://localhost:5000/api/recipes/generate`. To test/use, will need to generate your own [gemini API key](https://ai.google.dev/gemini-api/docs/api-key) and paste in `config.env`. Let me know if there's any issues or anything I should change!