### PR TITLE
Feat/reroute result recipe page

### DIFF
--- a/frontend/app/components/SearchBar.jsx
+++ b/frontend/app/components/SearchBar.jsx
@@ -12,7 +12,6 @@ export default function SearchBar() {
   const [cuisine, setCuisine] = useState('Any');
   const [loading, setLoading] = useState(false);
   const [inputError, setInputError] = useState(false); // State to track input error
-
   const router = useRouter();
 
   const handleInputChange = (e) => {
@@ -64,6 +63,7 @@ export default function SearchBar() {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 
+      // Trigger a page refresh by updating the query parameter
       router.push('/result');
     } catch (error) {
       console.error('Error fetching or storing the recipe:', error);

--- a/frontend/app/components/SearchBar.jsx
+++ b/frontend/app/components/SearchBar.jsx
@@ -48,7 +48,7 @@ export default function SearchBar() {
       // call gemini to get recipes
       const data = await generateRecipe(ingredients, selectedCuisine, dietaryPreferences, selectedMealType, selectedServingSize);
 
-      // clear generated recipes in backend
+      // clear generated recipes in backend | have to call this after the api call otherwise no recipe data is shown
       await fetch('http://localhost:5000/api/server/generated-recipes', {
         method: 'DELETE',
       });
@@ -66,7 +66,6 @@ export default function SearchBar() {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 
-      // Trigger a page refresh by updating the query parameter
       router.push('/result');
     } catch (error) {
       console.error('Error fetching or storing the recipe:', error);

--- a/frontend/app/components/SearchBar.jsx
+++ b/frontend/app/components/SearchBar.jsx
@@ -44,13 +44,14 @@ export default function SearchBar() {
     setLoading(true);
 
     try {
+
+      // call gemini to get recipes
+      const data = await generateRecipe(ingredients, selectedCuisine, dietaryPreferences, selectedMealType, selectedServingSize);
+
       // clear generated recipes in backend
       await fetch('http://localhost:5000/api/server/generated-recipes', {
         method: 'DELETE',
       });
-
-      // call gemini to get recipes
-      const data = await generateRecipe(ingredients, selectedCuisine, dietaryPreferences, selectedMealType, selectedServingSize);
 
       // store generated recipes in backend
       const response = await fetch('http://localhost:5000/api/server/generated-recipes', {

--- a/frontend/app/components/SearchBar.jsx
+++ b/frontend/app/components/SearchBar.jsx
@@ -48,6 +48,8 @@ export default function SearchBar() {
       await fetch('http://localhost:5000/api/server/generated-recipes', {
         method: 'DELETE',
       });
+
+      // call gemini to get recipes
       const data = await generateRecipe(ingredients, selectedCuisine, dietaryPreferences, selectedMealType, selectedServingSize);
 
       // store generated recipes in backend

--- a/frontend/app/lib/api.js
+++ b/frontend/app/lib/api.js
@@ -23,6 +23,7 @@ export async function generateRecipe(ingredients, cuisine, dietaryPreferences, m
         throw new Error(`Error: ${response.statusText}`);
       }
       const data = await response.json();
+
         // Add result-id to each recipe
         return data.map((recipe, index) => ({
             ...recipe,

--- a/frontend/app/lib/api.js
+++ b/frontend/app/lib/api.js
@@ -23,7 +23,12 @@ export async function generateRecipe(ingredients, cuisine, dietaryPreferences, m
         throw new Error(`Error: ${response.statusText}`);
       }
       const data = await response.json();
-      return data;
+        // Add result-id to each recipe
+        return data.map((recipe, index) => ({
+            ...recipe,
+            'result-id': index,
+        }));
+
     } catch (error) {
       console.error('Failed to generate recipes:', error);
       throw error;

--- a/frontend/app/recipe-result/page.js
+++ b/frontend/app/recipe-result/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, Divider } from "@nextui-org/react";
 import RecipeImage from './RecipeImage';
 import Ingredients from './Ingredients';
@@ -8,23 +8,28 @@ import RecipeHeader from './RecipeHeader';
 import RecipeInstructions from './RecipeInstructions';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-
 export default function RecipePage() {
     const [recipe, setRecipe] = useState(null);
     const searchParams = useSearchParams();
 
-    // use query params to get recipe
     useEffect(() => {
-        const recipeParam = searchParams.get('recipe');
+        const resultId = searchParams.get('result-id');
+        if (resultId) {
+            // Fetch the recipe by result-id
+            const fetchRecipe = async () => {
+                try {
+                    const response = await fetch(`http://localhost:5000/api/server/generated-recipes/${resultId}`);
+                    if (!response.ok) {
+                        throw new Error(`Error: ${response.statusText}`);
+                    }
+                    const recipeData = await response.json();
+                    setRecipe(recipeData);
+                } catch (error) {
+                    console.error("Failed to fetch recipe data:", error);
+                }
+            };
 
-        if (recipeParam) {
-            try {
-                const deserializedRecipe = JSON.parse(decodeURIComponent(recipeParam));
-                setRecipe(deserializedRecipe);
-                console.log(deserializedRecipe);
-            } catch (error) {
-                console.error("Failed to parse recipe data:", error);
-            }
+            fetchRecipe();
         }
     }, [searchParams]);
 
@@ -46,7 +51,7 @@ export default function RecipePage() {
                 <div style={styles.rightSide}>
                     <RecipeHeader title={recipe.title} onSave={handleSaveRecipe} />
                     <Divider />
-                    <RecipeInstructions instructions={recipe.instructions} cookingTime = {recipe.cookingTime} />
+                    <RecipeInstructions instructions={recipe.instructions} cookingTime={recipe.cookingTime} />
                 </div>
             </Card>
         </div>

--- a/frontend/app/result/page.js
+++ b/frontend/app/result/page.js
@@ -17,8 +17,8 @@ export default function App() {
     const [recipeData, setRecipeData] = useState([]);
     const router = useRouter();
 
+    // get the recipes from the backend
     useEffect(() => {
-        // Fetch the recipes from the backend
         const fetchRecipes = async () => {
             try {
                 const response = await fetch('http://localhost:5000/api/server/generated-recipes');
@@ -37,13 +37,12 @@ export default function App() {
 
     // send to recipe-result screen
     async function handleViewButtonClick(recipe) {
-        // Ensure the recipe has a result-id
         if (recipe['result-id'] === null || recipe['result-id'] === undefined) {
             console.error('Recipe does not have a result-id');
             return;
         }
 
-        // Add the result-id as a query parameter
+        // add resultId as query param
         const resultId = recipe['result-id'];
         router.push(`/recipe-result?result-id=${resultId}`);
     }

--- a/frontend/app/result/page.js
+++ b/frontend/app/result/page.js
@@ -37,8 +37,15 @@ export default function App() {
 
   // send to recipe-result screen
   async function handleViewButtonClick(recipe) {
-      const serializedRecipe = encodeURIComponent(JSON.stringify(recipe));
-      router.push(`/recipe-result?recipe=${serializedRecipe}`);
+      // Ensure the recipe has a result-id
+      if (recipe['result-id'] === null || recipe['result-id'] === undefined) {
+          console.error('Recipe does not have a result-id');
+          return;
+      }
+
+      // Add the result-id as a query parameter
+      const resultId = recipe['result-id'];
+      router.push(`/recipe-result?result-id=${resultId}`);
   }
 
   const renderCell = React.useCallback(

--- a/frontend/app/result/page.js
+++ b/frontend/app/result/page.js
@@ -2,138 +2,138 @@
 
 import React, { useEffect, useState } from "react";
 import {
-  Table,
-  TableHeader,
-  TableColumn,
-  TableBody,
-  TableRow,
-  TableCell,
-  Chip,
-  Button,
+    Table,
+    TableHeader,
+    TableColumn,
+    TableBody,
+    TableRow,
+    TableCell,
+    Chip,
+    Button,
 } from "@nextui-org/react";
 import { useRouter } from "next/navigation";
 
 export default function App() {
-  const [recipeData, setRecipeData] = useState([]);
-  const router = useRouter();
+    const [recipeData, setRecipeData] = useState([]);
+    const router = useRouter();
 
-  useEffect(() => {
-    // Fetch the recipes from the backend
-    const fetchRecipes = async () => {
-      try {
-        const response = await fetch('http://localhost:5000/api/server/generated-recipes');
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+    useEffect(() => {
+        // Fetch the recipes from the backend
+        const fetchRecipes = async () => {
+            try {
+                const response = await fetch('http://localhost:5000/api/server/generated-recipes');
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                const data = await response.json();
+                setRecipeData(data.generatedRecipes || []);
+            } catch (error) {
+                console.error('Error fetching recipes:', error);
+            }
+        };
+
+        fetchRecipes();
+    });
+
+    // send to recipe-result screen
+    async function handleViewButtonClick(recipe) {
+        // Ensure the recipe has a result-id
+        if (recipe['result-id'] === null || recipe['result-id'] === undefined) {
+            console.error('Recipe does not have a result-id');
+            return;
         }
-        const data = await response.json();
-        setRecipeData(data.generatedRecipes || []);
-      } catch (error) {
-        console.error('Error fetching recipes:', error);
-      }
-    };
 
-    fetchRecipes();
-  });
+        // Add the result-id as a query parameter
+        const resultId = recipe['result-id'];
+        router.push(`/recipe-result?result-id=${resultId}`);
+    }
 
-  // send to recipe-result screen
-  async function handleViewButtonClick(recipe) {
-      // Ensure the recipe has a result-id
-      if (recipe['result-id'] === null || recipe['result-id'] === undefined) {
-          console.error('Recipe does not have a result-id');
-          return;
-      }
+    const renderCell = React.useCallback(
+        (recipe, columnKey) => {
+            switch (columnKey) {
+                case "recipe":
+                    return (
+                        <div>
+                            <p className="text-bold text-sm">{recipe.title}</p>
+                            <p className="text-sm text-default-400">Cook Time: {recipe.cookingTime}</p>
+                        </div>
+                    );
+                case "ingredients":
+                    return (
+                        <p className="text-sm text-default-600">
+                            {Array.isArray(recipe.ingredients) ? recipe.ingredients.join(", ") : "N/A"}
+                        </p>
+                    );
+                case "tags":
+                    const displayedTags = recipe.tags.slice(0, 3);
+                    return (
+                        <div className="flex gap-2">
+                            {displayedTags.map((tag) => (
+                                <Chip
+                                    key={tag}
+                                    className="capitalize"
+                                    color={"primary"}
+                                    size="sm"
+                                    variant="flat"
+                                >
+                                    {tag}
+                                </Chip>
+                            ))}
+                        </div>
+                    );
+                case "actions":
+                    return (
+                        <div className="relative flex items-center gap-2">
+                            <Button
+                                color="success"
+                                size="small"
+                                onClick={() => handleViewButtonClick(recipe)}
+                            >
+                                View
+                            </Button>
+                        </div>
+                    );
+                default:
+                    return null;
+            }
+        },
+        []
+    );
 
-      // Add the result-id as a query parameter
-      const resultId = recipe['result-id'];
-      router.push(`/recipe-result?result-id=${resultId}`);
-  }
-
-  const renderCell = React.useCallback(
-      (recipe, columnKey) => {
-        switch (columnKey) {
-          case "recipe":
-            return (
-                <div>
-                  <p className="text-bold text-sm">{recipe.title}</p>
-                  <p className="text-sm text-default-400">Cook Time: {recipe.cookingTime}</p>
-                </div>
-            );
-          case "ingredients":
-            return (
-                <p className="text-sm text-default-600">
-                  {Array.isArray(recipe.ingredients) ? recipe.ingredients.join(", ") : "N/A"}
-                </p>
-            );
-          case "tags":
-            const displayedTags = recipe.tags.slice(0, 3);
-            return (
-                <div className="flex gap-2">
-                  {displayedTags.map((tag) => (
-                      <Chip
-                          key={tag}
-                          className="capitalize"
-                          color={"primary"}
-                          size="sm"
-                          variant="flat"
-                      >
-                        {tag}
-                      </Chip>
-                  ))}
-                </div>
-            );
-          case "actions":
-            return (
-                <div className="relative flex items-center gap-2">
-                  <Button
-                      color="success"
-                      size="small"
-                      onClick={() => handleViewButtonClick(recipe)}
-                  >
-                    View
-                  </Button>
-                </div>
-            );
-          default:
-            return null;
-        }
-      },
-      []
-  );
-
-  // Render the table only if the recipe data is available
-  return recipeData.length > 0 ? (
-      <Table
-          aria-label="Recipe Details"
-          className="w-4/5 mx-auto mt-6 shadow-lg rounded-lg border border-gray-200"
-      >
-        <TableHeader>
-          <TableColumn key="recipe" align="start">
-            <span className="font-semibold text-lg text-gray-700">Recipe</span>
-          </TableColumn>
-          <TableColumn key="ingredients" align="start">
-            <span className="font-semibold text-lg text-gray-700">Ingredients</span>
-          </TableColumn>
-          <TableColumn key="tags" align="start">
-            <span className="font-semibold text-lg text-gray-700">Tags</span>
-          </TableColumn>
-          <TableColumn key="actions" align="center">
-            <span className="font-semibold text-lg text-gray-700">Actions</span>
-          </TableColumn>
-        </TableHeader>
-        <TableBody>
-          {recipeData.map((recipe, index) => (
-              <TableRow key={index}>
-                <TableCell>{renderCell(recipe, "recipe")}</TableCell>
-                <TableCell>{renderCell(recipe, "ingredients")}</TableCell>
-                <TableCell>{renderCell(recipe, "tags")}</TableCell>
-                <TableCell>{renderCell(recipe, "actions")}</TableCell>
-              </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-  ) : (
-      <div className="w-4/5 mx-auto mt-6">
-        <p className="text-center text-gray-500">No recipe data available.</p>
-      </div>
-  );
+    // Render the table only if the recipe data is available
+    return recipeData.length > 0 ? (
+        <Table
+            aria-label="Recipe Details"
+            className="w-4/5 mx-auto mt-6 shadow-lg rounded-lg border border-gray-200"
+        >
+            <TableHeader>
+                <TableColumn key="recipe" align="start">
+                    <span className="font-semibold text-lg text-gray-700">Recipe</span>
+                </TableColumn>
+                <TableColumn key="ingredients" align="start">
+                    <span className="font-semibold text-lg text-gray-700">Ingredients</span>
+                </TableColumn>
+                <TableColumn key="tags" align="start">
+                    <span className="font-semibold text-lg text-gray-700">Tags</span>
+                </TableColumn>
+                <TableColumn key="actions" align="center">
+                    <span className="font-semibold text-lg text-gray-700">Actions</span>
+                </TableColumn>
+            </TableHeader>
+            <TableBody>
+                {recipeData.map((recipe, index) => (
+                    <TableRow key={index}>
+                        <TableCell>{renderCell(recipe, "recipe")}</TableCell>
+                        <TableCell>{renderCell(recipe, "ingredients")}</TableCell>
+                        <TableCell>{renderCell(recipe, "tags")}</TableCell>
+                        <TableCell>{renderCell(recipe, "actions")}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ) : (
+        <div className="w-4/5 mx-auto mt-6">
+            <p className="text-center text-gray-500">No recipe data available.</p>
+        </div>
+    );
 }

--- a/frontend/app/result/page.js
+++ b/frontend/app/result/page.js
@@ -27,7 +27,6 @@ export default function App() {
         }
         const data = await response.json();
         setRecipeData(data.generatedRecipes || []);
-        router.refresh();
       } catch (error) {
         console.error('Error fetching recipes:', error);
       }

--- a/frontend/app/result/page.js
+++ b/frontend/app/result/page.js
@@ -27,13 +27,14 @@ export default function App() {
         }
         const data = await response.json();
         setRecipeData(data.generatedRecipes || []);
+        router.refresh();
       } catch (error) {
         console.error('Error fetching recipes:', error);
       }
     };
 
     fetchRecipes();
-  }, []);
+  });
 
   // send to recipe-result screen
   async function handleViewButtonClick(recipe) {

--- a/routes/server.js
+++ b/routes/server.js
@@ -26,4 +26,30 @@ router.delete('/generated-recipes', (req, res) => {
     res.json({ generatedRecipes: generated_recipes });
 });
 
+router.get('/generated-recipes/:resultId', (req, res) => {
+    console.log('Received request for recipe with resultId:', req.params.resultId);
+
+    const resultId = parseInt(req.params.resultId, 10);
+
+    if (isNaN(resultId)) {
+        console.error('Invalid resultId:', req.params.resultId);
+        return res.status(400).json({ error: 'Invalid result ID' });
+    }
+
+    // Check if resultId is within the bounds of the generated_recipes array
+    if (resultId < 0 || resultId > generated_recipes.length) {
+        console.error('Result ID out of range:', resultId);
+        return res.status(404).json({ error: 'Recipe not found' });
+    }
+
+    const recipe = generated_recipes.find(r => r['result-id'] === resultId);
+
+    if (recipe) {
+        res.json(recipe);
+    } else {
+        console.error('Recipe not found for resultId:', resultId);
+        res.status(404).json({ error: 'Recipe not found' });
+    }
+});
+
 module.exports = router;

--- a/routes/server.js
+++ b/routes/server.js
@@ -26,6 +26,7 @@ router.delete('/generated-recipes', (req, res) => {
     res.json({ generatedRecipes: generated_recipes });
 });
 
+// Endpoint to get a specific recipe
 router.get('/generated-recipes/:resultId', (req, res) => {
     console.log('Received request for recipe with resultId:', req.params.resultId);
 


### PR DESCRIPTION
Relating to issue #53 
Description:
Made it so that the recipe-result page pulls data from the backend instead of using query-params. 
Also fixed issue where new searches performed on the result page didn't reflect the new recipes

Notes:
Introduced new variable result-id which is used as a query-param and index for the recipe-result page. These changes have made things a little bit slower but worth it I think.

The generated_recipes array in the back-end is reset every search and the result-id's also reset every search too.
