### PR TITLE
Fixed invalid link with a error by adding package.

### DIFF
--- a/frontend/app/components/Header.jsx
+++ b/frontend/app/components/Header.jsx
@@ -6,10 +6,13 @@ import { Button } from "@nextui-org/react";
 export default function Header() {
   return (
     <div className="bg-white py-4 px-6 flex justify-between items-center">
-      <Link href="/" passHref>
-        <a className="text-4xl font-bold text-purple-700 cursor-pointer">
+      <Link
+        href="/"
+        passHref
+        className="text-4xl font-bold text-purple-700 cursor-pointer">
+        
           MEALMATCH
-        </a>
+        
       </Link>
       <div className="flex space-x-4">
         <Button color="primary" variant="ghost" size="lg">


### PR DESCRIPTION
Description:
Fixed the bug of " Invalid `<Link>` with `<a>` child" when compile frontend.
Fixed this by running npx @next/codemod new-link to update with  new <Link> usage


Notes:
According to nextjs 14 docs 
https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor